### PR TITLE
Fixing breaking issue in iOS 26.0.1

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,8 +8,13 @@ export * from "./GlassEffectViewNativeComponent";
 
 export type GlassEffectViewProps = Omit<InternalProps, "useContainerEffect">;
 
+const getIOSMajorVersion = (): number => {
+  const version = String(Platform.Version);
+  return parseInt(version.split('.')?.[0] ?? '0', 10);
+};
+
 export const isNativeModuleAvailable =
-  Platform.OS === "ios" && Number(Platform.Version) >= 26;
+  Platform.OS === "ios" && getIOSMajorVersion() >= 26;
 
 const GlassEffectViewImpl = (props: InternalProps) => {
   if (isNativeModuleAvailable && props.useNative !== false) {


### PR DESCRIPTION
This PR fixes an issue, where in the iOS version system parsing a version such as '26.0.1' will result in NaN.

Repro -
<img width="502" height="126" alt="Screenshot 2025-10-05 at 11 25 37 PM" src="https://github.com/user-attachments/assets/8c78ba9f-ea9a-4ace-8770-8bb9613c6ee1" />

The package fails to show glass effect in iOS 26.0.1, this PR fixes the same.
