### PR TITLE
fix: sync UIVisualEffectView frame in layoutSubviews

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Text,
   StyleSheet,
@@ -7,8 +7,56 @@ import {
   Switch,
   SafeAreaView,
   Image,
+  Pressable,
 } from 'react-native';
 import { GlassEffectView } from 'react-native-glass-effect-view';
+
+/**
+ * Demonstrates the layoutSubviews fix.
+ *
+ * Without the fix, the "Delayed Mount" cards render as completely transparent
+ * because the UIVisualEffectView frame is never synced with its parent bounds
+ * when the component mounts during an async state transition.
+ *
+ * Tap "Toggle Delayed Cards" to show/hide the conditionally-mounted cards.
+ * They should render with the glass effect immediately on mount.
+ */
+const DelayedMountDemo = () => {
+  const [showCards, setShowCards] = useState(false);
+  const [showDelayedCards, setShowDelayedCards] = useState(false);
+
+  // Simulate an async state transition (e.g., loading → content)
+  useEffect(() => {
+    if (showCards) {
+      const timer = setTimeout(() => setShowDelayedCards(true), 500);
+      return () => clearTimeout(timer);
+    }
+    setShowDelayedCards(false);
+  }, [showCards]);
+
+  return (
+    <View style={styles.demoSection}>
+      <Pressable
+        onPress={() => setShowCards((prev) => !prev)}
+        style={styles.toggleButton}
+      >
+        <Text style={styles.toggleText}>
+          {showCards ? 'Hide Delayed Cards' : 'Show Delayed Cards'}
+        </Text>
+      </Pressable>
+      {showDelayedCards && (
+        <View style={styles.cardRow}>
+          <GlassEffectView style={styles.card}>
+            <Text style={styles.cardText}>Delayed{'\n'}Mount 1</Text>
+          </GlassEffectView>
+          <GlassEffectView style={styles.card}>
+            <Text style={styles.cardText}>Delayed{'\n'}Mount 2</Text>
+          </GlassEffectView>
+        </View>
+      )}
+    </View>
+  );
+};
 
 export default function App() {
   const [options, setOptions] = useState({
@@ -44,7 +92,7 @@ export default function App() {
                 fontWeight: '500',
               }}
             >
-              Hello World
+              Always Mounted
             </Text>
           </GlassEffectView>
           <GlassEffectView
@@ -65,6 +113,8 @@ export default function App() {
             />
           </GlassEffectView>
         </View>
+
+        <DelayedMountDemo />
       </ImageBackground>
 
       <SafeAreaView>
@@ -157,5 +207,38 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 30,
+  },
+  demoSection: {
+    marginTop: 24,
+    alignItems: 'center',
+    gap: 16,
+  },
+  toggleButton: {
+    backgroundColor: 'rgba(0,0,0,0.3)',
+    paddingHorizontal: 20,
+    paddingVertical: 10,
+    borderRadius: 12,
+  },
+  toggleText: {
+    color: '#fff',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+  cardRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  card: {
+    width: 140,
+    height: 80,
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cardText: {
+    color: 'rgba(255,255,255,0.8)',
+    fontSize: 14,
+    fontWeight: '500',
+    textAlign: 'center',
   },
 });

--- a/ios/GlassEffectView.mm
+++ b/ios/GlassEffectView.mm
@@ -54,6 +54,12 @@ using namespace facebook::react;
   _view.layer.cornerRadius = self.layer.cornerRadius;
 }
 
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  _view.frame = self.bounds;
+}
+
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
   [_view.contentView mountChildComponentView:childComponentView index:index];


### PR DESCRIPTION
## Problem

`GlassEffectView` renders as completely transparent when mounted during async state transitions — for example, conditional rendering (`{showContent && <GlassEffectView ... />}`), navigation transitions, or FlatList item recycling.

The "Always Mounted" glass cards work fine, but any `GlassEffectView` that mounts **after** the initial render (e.g., via `setTimeout`, state change, or navigation) appears invisible.

### Root Cause

The inner `UIVisualEffectView` (`_view`) is created in `initWithFrame:` and set as `self.contentView`, but its frame is **never updated** when the parent view's bounds change.

On Fabric (React Native new architecture), the component's bounds are set by the layout engine **after** mount. Without `layoutSubviews`, the `UIVisualEffectView` keeps its initial zero-size frame — the glass effect has nothing to render into.

### Fix

Added `layoutSubviews` to sync `_view.frame` with `self.bounds` on every layout pass:

```objc
- (void)layoutSubviews
{
  [super layoutSubviews];
  _view.frame = self.bounds;
}
```

This is a standard UIKit pattern for keeping subview frames in sync with their parent.

### Reproduction

The example app now includes a "Delayed Mount" demo:
- Tap **Show Delayed Cards** — two `GlassEffectView` cards mount after a 500ms delay
- **Without fix:** cards render transparent (no glass effect visible)
- **With fix:** glass effect renders immediately on mount

### Testing

- Verified on iOS 26.3 simulator and iOS 26.3.1 physical device
- Existing glass cards ("Always Mounted") continue to work correctly
- No behavioral changes for already-mounted components